### PR TITLE
Fix loan approval display logic to handle API errors

### DIFF
--- a/lib/widgets/loan_form.dart
+++ b/lib/widgets/loan_form.dart
@@ -35,17 +35,15 @@ class _LoanFormState extends State<LoanForm> {
       final result = await _apiService.requestLoanDecision(
           _nationalId, _loanAmount, _loanPeriod);
       setState(() {
-        int tempAmount = int.parse(result['loanAmount'].toString());
-        int tempPeriod = int.parse(result['loanPeriod'].toString());
+        _errorMessage = result['errorMessage'].toString();
 
-        if (tempAmount <= _loanAmount || tempPeriod > _loanPeriod) {
+        if (_errorMessage == '') {
           _loanAmountResult = int.parse(result['loanAmount'].toString());
           _loanPeriodResult = int.parse(result['loanPeriod'].toString());
         } else {
-          _loanAmountResult = _loanAmount;
-          _loanPeriodResult = _loanPeriod;
+          _loanAmountResult = 0;
+          _loanPeriodResult = 0;
         }
-        _errorMessage = result['errorMessage'].toString();
       });
     } else {
       _loanAmountResult = 0;
@@ -152,7 +150,7 @@ class _LoanFormState extends State<LoanForm> {
                           padding: EdgeInsets.only(left: 12),
                           child: Align(
                               alignment: Alignment.centerLeft,
-                              child: Text('6 months')),
+                              child: Text('12 months')),
                         ),
                       ),
                       Expanded(


### PR DESCRIPTION
Modify the _submitForm method to ensure that approved loan values are not updated when the API returns an error. Now, in case of an error, the approved loan amount and period revert to zero, clearly indicating that the loan has not been approved. This prevents misleading displays of unapproved loan amounts when the slider is adjusted beyond valid